### PR TITLE
Fix issue where .js source file is not renamed properly

### DIFF
--- a/rename.json
+++ b/rename.json
@@ -3,6 +3,6 @@
 	"assets/css/less/theme.less": "assets/css/less/{%= js_safe_name %}.less",
 	"assets/css/sass/theme.scss": "assets/css/sass/{%= js_safe_name %}.scss",
 	"assets/css/src/theme.css": "assets/css/src/{%= js_safe_name %}.css",
-	"assets/css/js/src/theme.js": "assets/css/js/src/{%= js_safe_name %}.js",
+	"assets/js/src/theme.js": "assets/js/src/{%= js_safe_name %}.js",
 	"languages/theme.pot": "languages/{%= prefix %}.pot"
 }


### PR DESCRIPTION
The path in the `rename.json` is incorrect for the JS file, which causes Grunt to look for a user's code in the wrong place. Removing `/css` from the file path fixes the issue.
