### PR TITLE
Move JSHint options into an external .jshintrc file

### DIFF
--- a/root/.jshintrc
+++ b/root/.jshintrc
@@ -1,0 +1,19 @@
+{
+	"boss":    true,
+	"browser": true,
+	"curly":   true,
+	"eqeqeq":  true,
+	"eqnull":  true,
+	"immed":   true,
+	"jquery":  true,
+	"latedef": true,
+	"newcap":  true,
+	"noarg":   true,
+  "quotmark": true,
+	"sub":     true,
+	"undef":   true,
+	"globals": {
+		"exports": true,
+		"module":  false
+	}
+}

--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -1,4 +1,5 @@
 module.exports = function( grunt ) {
+	'use strict';
 
 	// Project configuration
 	grunt.initConfig( {
@@ -26,21 +27,8 @@ module.exports = function( grunt ) {
 				'assets/js/test/**/*.js'
 			],
 			options: {
-				curly:   true,
-				eqeqeq:  true,
-				immed:   true,
-				latedef: true,
-				newcap:  true,
-				noarg:   true,
-				sub:     true,
-				undef:   true,
-				boss:    true,
-				eqnull:  true,
-				globals: {
-					exports: true,
-					module:  false
-				}
-			}		
+				jshintrc: '.jshintrc'
+			}
 		},
 		uglify: {
 			all: {
@@ -76,7 +64,7 @@ module.exports = function( grunt ) {
 				files: {
 					'assets/css/{%= js_safe_name %}.css': 'assets/css/less/{%= js_safe_name %}.less'
 				}
-			}		
+			}
 		},
 		{% } %}
 		cssmin: {
@@ -90,7 +78,7 @@ module.exports = function( grunt ) {
 			minify: {
 				expand: true,
 				{% if ('sass' === css_type || 'less' === css_type) { %}
-				cwd: 'assets/css/',				
+				cwd: 'assets/css/',
 				src: ['{%= js_safe_name %}.css'],
 				{% } else { %}
 				cwd: 'assets/css/src/',
@@ -135,7 +123,7 @@ module.exports = function( grunt ) {
 			}
 		}
 	} );
-	
+
 	// Load other tasks
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-concat');
@@ -147,7 +135,7 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks('grunt-contrib-less');
 	{% } %}
 	grunt.loadNpmTasks('grunt-contrib-watch');
-	
+
 	// Default task.
 	{% if ('sass' === css_type) { %}
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'cssmin'] );


### PR DESCRIPTION
While adding a `.jshintrc` admittedly created another mystery file that could conceivably confuse a user, it's the recommended way to configure JSHint and many editors can take advantage of these settings if they live within an external file.

Additional changes:
- Properties within `.jshintrc` have been sorted alphabetically.
- `jquery` and `browser` JSHint options have been set in .jshint, to reflect the most common JavaScript environment for WordPress developers
- `quotmark` JSHint option has been set to encourage consistency without enforcing an opinion on single- vs double-quotes
- The Gruntfile itself has been edited to pass `strict` and `trailing` JSHint tests by default, although I left those out of the default `.jshintrc` (along with many of the other more opinionated flags)
