### PR TITLE
update grunt-contrib-sass to a minimum of 0.8.0 to support sourcemap

### DIFF
--- a/template.js
+++ b/template.js
@@ -53,7 +53,7 @@ exports.template = function( grunt, init, done ) {
 			'grunt-contrib-nodeunit': '~0.1.2',
 			'grunt-contrib-watch': '~0.2.0',
 		};
-		
+
 		// Sanitize names where we need to for PHP/JS
 		props.name = props.title.replace( /\s+/g, '-' ).toLowerCase();
 		// Development prefix (i.e. to prefix PHP function names, variables)
@@ -73,7 +73,7 @@ exports.template = function( grunt, init, done ) {
 			case 'l':
 				delete files[ 'assets/css/sass/' + props.js_safe_name + '.scss'];
 				delete files[ 'assets/css/src/' + props.js_safe_name + '.css' ];
-				
+
 				props.devDependencies["grunt-contrib-less"] = "~0.11.2";
 				props.css_type = 'less';
 				break;
@@ -81,27 +81,27 @@ exports.template = function( grunt, init, done ) {
 			case undefined:
 				delete files[ 'assets/css/less/' + props.js_safe_name + '.less'];
 				delete files[ 'assets/css/sass/' + props.js_safe_name + '.scss'];
-				
+
 				props.css_type = 'none';
 				break;
 			// SASS is the default
 			default:
 				delete files[ 'assets/css/less/' + props.js_safe_name + '.less'];
 				delete files[ 'assets/css/src/' + props.js_safe_name + '.css' ];
-				
-				props.devDependencies["grunt-contrib-sass"] = "~0.7.3";
+
+				props.devDependencies["grunt-contrib-sass"] = "~0.8.0";
 				props.css_type = 'sass';
 				break;
 		}
-		
+
 		console.log( files );
-		
+
 		// Actually copy and process files
 		init.copyAndProcess( files, props );
-		
+
 		// Generate package.json file
 		init.writePackageJSON( 'package.json', props );
-		
+
 		// Done!
 		done();
 	});


### PR DESCRIPTION
grunt-contrib-sass ~0.8.0 has support for Sass sourcemaps. This version will output the sourcemap by default.
