### PR TITLE
Update template.js to fix image corruption

### DIFF
--- a/template.js
+++ b/template.js
@@ -100,7 +100,7 @@ exports.template = function( grunt, init, done ) {
 		init.copyAndProcess( files, props );
 
 		// Generate package.json file
-		init.writePackageJSON( 'package.json', props );
+		init.writePackageJSON( 'package.json', props, {noProcess: 'screenshot.png''} );
 
 		// Done!
 		done();


### PR DESCRIPTION
excludes process on screenshot.png which was being corrupted before

If you need to add more images to the exclusion in the future, list as an array.