### PR TITLE
Localization, Namespacing and Sub-namespacing ( Requires PHP 5.3+ )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 defaults.json
+.sass-cache

--- a/README.md
+++ b/README.md
@@ -51,11 +51,17 @@ After running the init command above, you will be presented with a standard dire
     .. .. .. /src
     .. /images
     .. .. /src
-    .. /includes
+    .. /inc
+    .. .. /cache
+    .. .. /classes
+    .. .. /functions
+    .. .. .. header.php
+    .. .. .. theme.php
     .. /languages
     .. .. theme.pot
     .. .gitignore
     .. Gruntfile.js
+    .. constants.php
     .. footer.php
     .. functions.php
     .. header.php

--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function( grunt ) {
 				options: {
 					jshintrc: '.gruntjshintrc'
 				}
-			}   
+			}
 		},
 		uglify: {
 			all: {
@@ -133,8 +133,45 @@ module.exports = function( grunt ) {
 					debounceDelay: 500
 				}
 			}
+		},
+		pot: {
+			options:{
+				text_domain: '{%= js_safe_name %}', //Your text domain. Produces my-text-domain.pot
+				dest: 'languages/', //directory to place the pot file
+				keywords: [ //WordPress localisation functions
+					'__:1',
+					'_e:1',
+					'_x:1,2c',
+					'esc_html__:1',
+					'esc_html_e:1',
+					'esc_html_x:1,2c',
+					'esc_attr__:1',
+					'esc_attr_e:1',
+					'esc_attr_x:1,2c',
+					'_ex:1,2c',
+					'_n:1,2',
+					'_nx:1,2,4c',
+					'_n_noop:1,2',
+					'_nx_noop:1,2,3c'
+				]
+			},
+			files:{
+				src:  [ '**/*.php' ], //Parse all php files
+				expand: true
+			}
+		},
+
+		po2mo: {
+			files: {
+				src: 'languages/*.po',
+				expand: true
+			}
 		}
 	} );
+
+	// Translation
+	grunt.loadNpmTasks( 'grunt-pot' );
+	grunt.loadNpmTasks( 'grunt-po2mo' );
 
 	// Default task.
 	{% if ('sass' === css_type) { %}

--- a/root/constants.php
+++ b/root/constants.php
@@ -5,7 +5,7 @@
  * @since 0.1.0
  */
 
-namespace { %= prefix_caps % }\Constants;
+namespace {%= prefix_caps %}\Constants;
 
 // Useful global constants
 if ( ! defined( '{%= prefix_caps %}_VERSION' ) ) {

--- a/root/constants.php
+++ b/root/constants.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * {%= title %} theme constants
+ * @package {%= title %}
+ * @since 0.1.0
+ */
+
+namespace { %= prefix_caps % }\Constants;
+
+// Useful global constants
+if ( ! defined( '{%= prefix_caps %}_VERSION' ) ) {
+	define( '{%= prefix_caps %}_VERSION', '0.1.0' );
+}

--- a/root/footer.php
+++ b/root/footer.php
@@ -5,3 +5,6 @@
  * @package {%= title %}
  * @since 0.1.0
  */
+
+wp_footer(); ?>
+</html>

--- a/root/functions.php
+++ b/root/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * {%= title %} functions and definitions
+ * {%= title %} functions and setups
  *
  * When using a child theme (see http://codex.wordpress.org/Theme_Development and
  * http://codex.wordpress.org/Child_Themes), you can override certain functions
@@ -11,49 +11,22 @@
  * @package {%= title %}
  * @since 0.1.0
  */
- 
- // Useful global constants
-define( '{%= prefix_caps %}_VERSION', '0.1.0' );
- 
- /**
-  * Set up theme defaults and register supported WordPress features.
-  *
-  * @uses load_theme_textdomain() For translation/localization support.
-  *
-  * @since 0.1.0
-  */
- function {%= prefix %}_setup() {
-	/**
-	 * Makes {%= title %} available for translation.
-	 *
-	 * Translations can be added to the /lang directory.
-	 * If you're building a theme based on {%= title %}, use a find and replace
-	 * to change '{%= prefix %}' to the name of your theme in all template files.
-	 */
-	load_theme_textdomain( '{%= prefix %}', get_template_directory() . '/languages' );
- }
- add_action( 'after_setup_theme', '{%= prefix %}_setup' );
- 
- /**
-  * Enqueue scripts and styles for front-end.
-  *
-  * @since 0.1.0
-  */
- function {%= prefix %}_scripts_styles() {
-	$postfix = ( defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ) ? '' : '.min';
 
-	wp_enqueue_script( '{%= prefix %}', get_template_directory_uri() . "/assets/js/{%= js_safe_name %}{$postfix}.js", array(), {%= prefix_caps %}_VERSION, true );
-		
-	wp_enqueue_style( '{%= prefix %}', get_template_directory_uri() . "/assets/css/{%= js_safe_name %}{$postfix}.css", array(), {%= prefix_caps %}_VERSION );
- }
- add_action( 'wp_enqueue_scripts', '{%= prefix %}_scripts_styles' );
- 
- /**
-  * Add humans.txt to the <head> element.
-  */
- function {%= prefix %}_header_meta() {
-	$humans = '<link type="text/plain" rel="author" href="' . get_template_directory_uri() . '/humans.txt" />';
-	
-	echo apply_filters( '{%= prefix %}_humans', $humans );
- }
- add_action( 'wp_head', '{%= prefix %}_header_meta' );
+namespace {%= prefix_caps %};
+
+/**
+ * Define the namespace and constants
+ */
+require_once( __DIR__ . '/constants.php' );
+
+/**
+ * Load the cache, classes, functions
+ */
+require_once( __DIR__ . '/inc/functions/header.php' );
+require_once( __DIR__ . '/inc/functions/theme.php' );
+
+/**
+ * Setup the functions
+ */
+{%= prefix_caps %}\Theme\setup();
+{%= prefix_caps %}\Header\setup();

--- a/root/header.php
+++ b/root/header.php
@@ -6,3 +6,4 @@
  * @since 0.1.0
  */
  ?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>

--- a/root/inc/README.md
+++ b/root/inc/README.md
@@ -1,0 +1,3 @@
+# Includes
+
+All theme classes, objects, and libraries should be hidden away in this `/inc` directory.

--- a/root/inc/cache/README.md
+++ b/root/inc/cache/README.md
@@ -1,0 +1,3 @@
+# Includes
+
+All theme caching functions and classes should be hidden away in this `/inc/cache` directory.

--- a/root/inc/classes/README.md
+++ b/root/inc/classes/README.md
@@ -1,0 +1,3 @@
+# Includes
+
+All theme classes should be hidden away in this `/inc/classes` directory.

--- a/root/inc/functions/README.md
+++ b/root/inc/functions/README.md
@@ -1,0 +1,3 @@
+# Includes
+
+All theme functions should be hidden away in this `/inc/functions` directory.

--- a/root/inc/functions/header.php
+++ b/root/inc/functions/header.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * {%= title %} header functions
+ * @package {%= title %}
+ * @since 0.1.0
+ */
+
+namespace {%= prefix_caps %}\Header;
+
+/**
+ * Setup the actions and filters used in this file
+ * @uses add_action() wp_head header_meta()
+ * @since 0.1.0
+ */
+function setup() {
+	add_action( 'wp_head', __NAMESPACE__ . '\\header_meta' );
+}
+/**
+ * Add humans.txt to the <head> element.
+ */
+function header_meta() {
+	$humans = '<link type="text/plain" rel="author" href="' . get_template_directory_uri() . '/humans.txt" />';
+
+	echo apply_filters( '{%= prefix %}_humans', $humans );
+}

--- a/root/inc/functions/theme.php
+++ b/root/inc/functions/theme.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * {%= title %} theme functions
+ * @package {%= title %}
+ * @since 0.1.0
+ */
+
+namespace {%= prefix_caps %}\Theme;
+
+/**
+ * Adds actions and filters for more general theme functions
+ *
+ * @uses add_action() wp_enqueue_scripts scripts(), styles()
+ * @uses add_action() after_setup_theme theme_setup()
+ * @since 0.1.0
+ */
+function setup() {
+
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\scripts' );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\styles' );
+	add_action( 'after_setup_theme', __NAMESPACE__ . '\\theme_setup' );
+}
+
+/**
+ * Enqueue styles for front-end.
+ *
+ * @action wp_enqueue_scripts()
+ * @uses wp_enqueue_script()
+ * @since 0.1.0
+ */
+function styles() {
+	$postfix = ( defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ) ? '' : '.min';
+	wp_enqueue_style( '{%= prefix %}', get_template_directory_uri() . "/assets/css/{%= js_safe_name %}{$postfix}.css", array(), { %= prefix_caps % }_VERSION );
+}
+
+/**
+ * Enqueue styles for front-end.
+ *
+ * @action wp_enqueue_scripts()
+ * @uses wp_enqueue_script()
+ * @since 0.1.0
+ */
+function scripts() {
+	$postfix = ( defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ) ? '' : '.min';
+	wp_enqueue_script( '{%= prefix %}', get_template_directory_uri() . "/assets/js/{%= js_safe_name %}{$postfix}.js", array(), { %= prefix_caps % }_VERSION, true );
+}
+
+/**
+ * Set up theme supports and localization.
+ *
+ * @action after_setup_theme
+ * @uses add_theme_support() For post-thumbnails and automatic-feed-links
+ * @uses add_editor_style() Adding custom styles to the editor
+ * @uses load_theme_textdomain() Theme localization
+ * @since 0.1.0
+ */
+function theme_setup() {
+	add_theme_support( 'post-thumbnails' );
+	add_theme_support( 'automatic-feed-links' );
+
+	// Add language support
+	load_theme_textdomain( '{%= prefix %}', get_template_directory() . '/languages' );
+}

--- a/root/includes/README.md
+++ b/root/includes/README.md
@@ -1,3 +1,0 @@
-# Includes
-
-All theme classes, objects, and libraries should be hidden away in this `/includes` directory.

--- a/template.js
+++ b/template.js
@@ -52,6 +52,8 @@ exports.template = function( grunt, init, done ) {
 			'grunt-contrib-jshint': '~0.10.0',
 			'grunt-contrib-nodeunit': '~0.4.1',
 			'grunt-contrib-watch': '~0.6.1',
+			'grunt-pot': '^0.1.2',
+			'grunt-po2mo': '~0.1.2'
 		};
 
 		// Sanitize names where we need to for PHP/JS


### PR DESCRIPTION
Per 10up Engineering Best Practices:

> All functional code should be properly namespaced. We do this to logically organize our code and to prevent collisions in the global namespace.

WordPress currently requires a minimum of PHP 5.2+ ( 18.7% usage ). 
However, use of namespacing requires a minimum of PHP 5.3+ ( 44.7% usage ).
Namespace allthethings!
Includes localization updates.
- [Read More at 10up Engineering Best Practices / Namespacing](https://10up.github.io/Engineering-Best-Practices/php/#namespacing)

@ericmann: Submitting pull request for when WordPress updates minimum PHP requirements. :)
