### PR TITLE
Add SassDoc, if CSS Preprocessor is Sass.

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -100,6 +100,7 @@ module.exports = function( grunt ) {
 				ext: '.min.css'
 			}
 		},
+		{% if ('sass' === css_type) { %}
 		sassdoc: {
 		    default: {
 		        src: 'assets/css/sass',
@@ -117,6 +118,7 @@ module.exports = function( grunt ) {
 		        }
 		    }
 		},
+		{% } %}
 		watch:  {
 			{% if ('sass' === css_type) { %}
 			sass: {

--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function( grunt ) {
 				options: {
 					jshintrc: '.gruntjshintrc'
 				}
-			}   
+			}
 		},
 		uglify: {
 			all: {
@@ -99,6 +99,23 @@ module.exports = function( grunt ) {
 				dest: 'assets/css/',
 				ext: '.min.css'
 			}
+		},
+		sassdoc: {
+		    default: {
+		        src: 'assets/css/sass',
+		        dest: 'docs',
+		        options: {
+		            groups: {
+		                'undefined': 'General',
+		                'helpers': 'Helpers',
+		                'breakpoints': 'Media Queries',
+		                'fonts': 'Fonts',
+		                'display': 'Display',
+		                'grid': 'Grid',
+		            },
+		            force: true
+		        }
+		    }
 		},
 		watch:  {
 			{% if ('sass' === css_type) { %}

--- a/template.js
+++ b/template.js
@@ -52,6 +52,8 @@ exports.template = function( grunt, init, done ) {
 			'grunt-contrib-jshint': '~0.10.0',
 			'grunt-contrib-nodeunit': '~0.4.1',
 			'grunt-contrib-watch': '~0.6.1',
+			'grunt-sassdoc': '~1.1.0',
+
 		};
 
 		// Sanitize names where we need to for PHP/JS

--- a/template.js
+++ b/template.js
@@ -53,7 +53,6 @@ exports.template = function( grunt, init, done ) {
 			'grunt-contrib-nodeunit': '~0.4.1',
 			'grunt-contrib-watch': '~0.6.1',
 			'grunt-sassdoc': '~1.1.0',
-
 		};
 
 		// Sanitize names where we need to for PHP/JS


### PR DESCRIPTION
- SassDoc parses your source folder to grab documentation-specific comments. From there, it builds a data tree, that gets enhanced and filtered before being passed to the view.
- Adds grunt-sassdoc plugin and task.
